### PR TITLE
Fix empty command panic, help for wrong "show" subcommand

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,6 +80,8 @@ func main() {
 		case line == "quit":
 		case line == "exit":
 			goto exit
+		case len(args) == 0:
+			break
 		// Command: show
 		case args[0] == "show":
 			if len(args) == 1 {
@@ -116,6 +118,8 @@ func main() {
 
 				fmt.Println(commands.ShowByPrefix(args[2], format))
 				break
+			default:
+				fmt.Println("Bad format. Please use 'show prefix|range'")
 			}
 
 			break


### PR DESCRIPTION
Current version will crash when I press Enter on empty command line.
```
genesis» 
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
main.main()
	/home/jkalina/Fantom/leveldb/leveldb-cli/main.go:84 +0xedc
```
Also when I try to use "show prefix" as "show (thePrefixIwantToFind)", no message is printed.
```
genesis» show myprefix
genesis»
```
This PR fixes both.